### PR TITLE
Update index.js to optionally use PORT from environment

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,8 @@ const log = require("debug")("index"); // See README.md on debugging
 // Server constants & variables
 
 const port = 80; // Port 80 is the default www port, if the server won't start then choose another port i.e. 3000, 8000, 8080
+// Use PORT environment variable or default to 80
+const port = process.env.PORT || 80;
 
 // Server side placeholders for data:
 let deviceList = []; // Placeholder for found devices through SSDP


### PR DESCRIPTION
This should be rejected since port is declared twice.  Sorry about this novice error.  I was on your repository and not mine, so the pull request/patch can't be undeleted.

To add the option for an external PORT variable to be set using docker, I'm looking to change like the following:

DEL const port = 80; // Port 80 is the default www port, if the server won't start then choose another port i.e. 3000, 8000, 8080
////
ADD // Use PORT environment variable or default to 80
ADD // Port 80 is the default www port, if the server won't start then choose another port i.e. 3000, 8000, 8080
ADD const port = process.env.PORT || 80;

I tested this with a fresh push to hub.docker.com and a fresh pull to a test LXC.  It works as expected with an external PORT variable set to 8080 which is the expected behaviour.

I have have this all working in a private registry on hub.docker.com, but I'd like to point to upstream (your repository) so that it always builds and pulls from there.

![Screenshot from 2025-01-22 17-48-44](https://github.com/user-attachments/assets/a9dc6f01-a94b-43f0-840c-6bd3007dc5e2)
