### PR TITLE
Fix artwork proxy rejecting AirPlay responses with missing Content-Type

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -172,9 +172,16 @@ app.get("/proxy-art", limiter, function (req, res) {
     https.get(targetUrl.href, options, (resp) => {
         // If the response is valid, pipe it to the client
         // Valid content-types could be: image/jpeg, image/png, image/webp, image/svg+xml, image/gif, etc.
-        if (!resp.headers['content-type'] || !resp.headers['content-type'].startsWith('image/')) {
+        const contentType = resp.headers['content-type'] || '';
+        if (contentType && !contentType.startsWith('image/')) {
             res.status(415).send("<div>Unsupported Media Type</div>");
             return;
+        }
+        // WiiM devices may omit Content-Type for AirPlay artwork; infer from URL extension
+        if (!contentType) {
+            const ext = targetUrl.pathname.split('.').pop().toLowerCase();
+            const mimeTypes = { jpeg: 'image/jpeg', jpg: 'image/jpeg', png: 'image/png', webp: 'image/webp', gif: 'image/gif', svg: 'image/svg+xml' };
+            resp.headers['content-type'] = mimeTypes[ext] || 'image/jpeg';
         }
         res.writeHead(resp.statusCode, resp.headers);
         resp.pipe(res);


### PR DESCRIPTION
## 🧾 Summary

WiiM devices omit the `Content-Type` header when serving AirPlay artwork over HTTPS. The `/proxy-art` endpoint treats this the same as a non-image Content-Type, returning 415 Unsupported Media Type — so AirPlay album art fails to load.

## 🔧 Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Chore (deps, refactor)
- [ ] Documentation

## ✔️ What was done?

- Only reject proxy responses where Content-Type is **present** and not an image type
- When Content-Type is missing, infer it from the URL file extension (defaults to `image/jpeg`)
- No impact on non-AirPlay sources — Spotify, DLNA, etc. already include proper Content-Type headers

## 🧪 Test information

Manual testing with AirPlay stream from iOS → WiiM Mini. Confirmed the device serves `https://<device-ip>/data/AirplayArtWorkData.jpeg` without a Content-Type header. After fix, proxy returns 200 with inferred `image/jpeg`.

## 📸 Screenshots (optional)

N/A

## ⛓️ Related issues

Related to #21 (Airplay - missing artwork)