### PR TITLE
Artwork proxy bug fix

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "1.8.5",
+  "version": "1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "1.8.5",
+      "version": "1.9",
       "license": "ISC",
       "devDependencies": {
         "@parcel/optimizer-htmlnano": "^2.16.4",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.8.5",
+  "version": "1.9",
   "description": "This folder contains all client related code.",
   "source": "./src/index.html",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wiim-now-playing",
-  "version": "1.8.5",
+  "version": "1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wiim-now-playing",
-      "version": "1.8.5",
+      "version": "1.9",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiim-now-playing",
-  "version": "1.8.5",
+  "version": "1.9",
   "description": "Show what the Wiim device is currently playing on a separate screen.",
   "main": "server/index.js",
   "scripts": {

--- a/server/__tests__/lib.test.js
+++ b/server/__tests__/lib.test.js
@@ -156,7 +156,7 @@ describe('lib.js', () => {
             expect(serverSettings2.features.lyrics.enabled).toBe(true); // Ongewijzigd
         });
 
-        test('moet de catch-tak aanroepen als readFileSync faalt', () => {
+        test('should call the catch block and invoke saveSettings when readFileSync fails', () => {
             // Force the catch block by making readFileSync throw
             fs.readFileSync.mockImplementation(() => { throw new Error('ENOENT: no such file or directory'); });
             fs.writeFile.mockImplementation(() => {}); // Prevent real disk write

--- a/server/__tests__/lib.test.js
+++ b/server/__tests__/lib.test.js
@@ -156,6 +156,18 @@ describe('lib.js', () => {
             expect(serverSettings2.features.lyrics.enabled).toBe(true); // Ongewijzigd
         });
 
+        test('moet de catch-tak aanroepen als readFileSync faalt', () => {
+            // Force the catch block by making readFileSync throw
+            fs.readFileSync.mockImplementation(() => { throw new Error('ENOENT: no such file or directory'); });
+            fs.writeFile.mockImplementation(() => {}); // Prevent real disk write
+
+            const serverSettings = { selectedDevice: {}, features: {} };
+            lib.getSettings(serverSettings);
+
+            // saveSettings is called inside the catch block
+            expect(fs.writeFile).toHaveBeenCalled();
+        });
+
         test('moet de branches van lyrics en cache checks volledig dekken (L104-113)', () => {
             // 1. Setup serverSettings met de volledige hiërarchie
             const serverSettings = {

--- a/server/__tests__/lyrics.test.js
+++ b/server/__tests__/lyrics.test.js
@@ -254,5 +254,70 @@ describe("Lyrics Module", () => {
             await lyrics.getLyricsForMetadata(mockIo, mockDeviceInfo, settingsZonderVersie);
             // Verifieer intern of getUserAgent 'unknown' bevatte
         });
+
+        test("should return missing-signature when TrackDuration is null or missing", async () => {
+            mockDeviceInfo.metadata = {
+                trackMetaData: {
+                    "dc:title": "Test Track",
+                    "upnp:artist": "Test Artist",
+                    "upnp:album": "Test Album"
+                }
+                // No TrackDuration
+            };
+            await lyrics.getLyricsForMetadata(mockIo, mockDeviceInfo, mockServerSettings);
+            expect(mockDeviceInfo.lyrics.status).toBe("missing-signature");
+        });
+
+        test("should parse numeric TrackDuration directly to seconds", async () => {
+            mockDeviceInfo.metadata = {
+                trackMetaData: {
+                    "dc:title": "Test Track",
+                    "upnp:artist": "Test Artist",
+                    "upnp:album": "Test Album"
+                },
+                TrackDuration: 200 // numeric type, should be passed directly to parseDurationToSeconds
+            };
+
+            const cachedData = { status: "ok", trackKey: expect.any(String), payload: { syncedLyrics: "test" } };
+            lyricsCache.get.mockResolvedValue(cachedData);
+
+            await lyrics.getLyricsForMetadata(mockIo, mockDeviceInfo, mockServerSettings);
+
+            // Should have looked up the cache with a key containing "200"
+            expect(lyricsCache.get).toHaveBeenCalledWith(expect.stringContaining("200"));
+        });
+
+        test("should parse mm:ss format TrackDuration to seconds", async () => {
+            mockDeviceInfo.metadata = {
+                trackMetaData: {
+                    "dc:title": "Test Track",
+                    "upnp:artist": "Test Artist",
+                    "upnp:album": "Test Album"
+                },
+                TrackDuration: "3:30" // mm:ss format = 210 seconds
+            };
+
+            const cachedData = { status: "ok", trackKey: expect.any(String), payload: { syncedLyrics: "test" } };
+            lyricsCache.get.mockResolvedValue(cachedData);
+
+            await lyrics.getLyricsForMetadata(mockIo, mockDeviceInfo, mockServerSettings);
+
+            // Should have looked up the cache with a key containing "210"
+            expect(lyricsCache.get).toHaveBeenCalledWith(expect.stringContaining("210"));
+        });
+
+        test("should skip re-emitting when clearLyricsState state is already the same", async () => {
+            mockServerSettings.features.lyrics.enabled = false;
+            mockDeviceInfo.lyrics = null;
+
+            // First call: sets state to disabled
+            await lyrics.getLyricsForMetadata(mockIo, mockDeviceInfo, mockServerSettings);
+            expect(mockIo.emit).toHaveBeenCalledWith("lyrics-get", expect.objectContaining({ status: "disabled" }));
+            const firstCallCount = mockIo.emit.mock.calls.length;
+
+            // Second call: clearLyricsState early-return fires because state is already "disabled" with null trackKey
+            await lyrics.getLyricsForMetadata(mockIo, mockDeviceInfo, mockServerSettings);
+            expect(mockIo.emit.mock.calls.length).toBe(firstCallCount);
+        });
     });
 });

--- a/server/__tests__/shell.test.js
+++ b/server/__tests__/shell.test.js
@@ -1,0 +1,125 @@
+// ===========================================================================
+// shell.test.js
+//
+// Unit tests for the shell.js module.
+// Uses Jest as the testing framework.
+// ===========================================================================
+
+jest.mock('child_process', () => ({
+    exec: jest.fn(),
+    execFile: jest.fn()
+}));
+jest.mock('debug', () => () => jest.fn());
+
+const childProcess = require('child_process');
+const shell = require('../lib/shell.js');
+
+describe('shell.js', () => {
+    let io;
+
+    beforeEach(() => {
+        io = { emit: jest.fn() };
+        jest.clearAllMocks();
+    });
+
+    describe('reboot', () => {
+        it('should emit server-reboot on successful exec', () => {
+            childProcess.exec.mockImplementation((cmd, cb) => cb(null, '', ''));
+
+            shell.reboot(io);
+
+            expect(childProcess.exec).toHaveBeenCalledWith(
+                '/usr/bin/sudo systemctl reboot',
+                expect.any(Function)
+            );
+            expect(io.emit).toHaveBeenCalledWith('server-reboot', 'Rebooting...');
+        });
+
+        it('should not emit if exec returns an error', () => {
+            childProcess.exec.mockImplementation((cmd, cb) => cb(new Error('Permission denied'), '', ''));
+
+            shell.reboot(io);
+
+            expect(io.emit).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('shutdown', () => {
+        it('should emit server-shutdown on successful exec', () => {
+            childProcess.exec.mockImplementation((cmd, cb) => cb(null, '', ''));
+
+            shell.shutdown(io);
+
+            expect(childProcess.exec).toHaveBeenCalledWith(
+                '/usr/bin/sudo systemctl poweroff',
+                expect.any(Function)
+            );
+            expect(io.emit).toHaveBeenCalledWith('server-shutdown', 'Shutting down...');
+        });
+
+        it('should not emit if exec returns an error', () => {
+            childProcess.exec.mockImplementation((cmd, cb) => cb(new Error('Permission denied'), '', ''));
+
+            shell.shutdown(io);
+
+            expect(io.emit).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('update', () => {
+        it('should emit updating then ok when git pull and npm install succeed', () => {
+            // git pull uses execFile(file, args, callback) - 3 args
+            childProcess.execFile.mockImplementationOnce((file, args, cb) => {
+                cb(null, 'Already up to date.', '');
+            });
+            // npm install uses execFile(file, args, options, callback) - 4 args
+            childProcess.execFile.mockImplementationOnce((file, args, opts, cb) => {
+                cb(null, 'added 0 packages', '');
+            });
+
+            shell.update(io);
+
+            expect(io.emit).toHaveBeenCalledWith('server-update', { status: 'updating' });
+            expect(io.emit).toHaveBeenCalledWith('server-update', {
+                status: 'ok',
+                git: 'Already up to date.',
+                npm: 'added 0 packages'
+            });
+        });
+
+        it('should emit error when git pull fails', () => {
+            const gitErr = new Error('Git pull failed');
+            childProcess.execFile.mockImplementationOnce((file, args, cb) => {
+                cb(gitErr, '', 'fatal: not a git repo');
+            });
+
+            shell.update(io);
+
+            expect(io.emit).toHaveBeenCalledWith('server-update', { status: 'updating' });
+            expect(io.emit).toHaveBeenCalledWith('server-update', expect.objectContaining({
+                status: 'error',
+                git: gitErr,
+                stderr: 'fatal: not a git repo'
+            }));
+        });
+
+        it('should emit error when npm install fails after successful git pull', () => {
+            const npmErr = new Error('npm install failed');
+            childProcess.execFile.mockImplementationOnce((file, args, cb) => {
+                cb(null, 'Already up to date.', '');
+            });
+            childProcess.execFile.mockImplementationOnce((file, args, opts, cb) => {
+                cb(npmErr, '', 'npm ERR! code ENOENT');
+            });
+
+            shell.update(io);
+
+            expect(io.emit).toHaveBeenCalledWith('server-update', { status: 'updating' });
+            expect(io.emit).toHaveBeenCalledWith('server-update', expect.objectContaining({
+                status: 'error',
+                npm: npmErr,
+                stderr: 'npm ERR! code ENOENT'
+            }));
+        });
+    });
+});

--- a/server/__tests__/ssdp.test.js
+++ b/server/__tests__/ssdp.test.js
@@ -1,0 +1,104 @@
+// ===========================================================================
+// ssdp.test.js
+//
+// Unit tests for the ssdp.js module.
+// Uses Jest as the testing framework.
+// ===========================================================================
+
+jest.mock('node-ssdp', () => ({
+    Client: jest.fn()
+}));
+jest.mock('../lib/upnpClient.js');
+jest.mock('debug', () => () => jest.fn());
+
+const { Client: SSDPClient } = require('node-ssdp');
+const upnp = require('../lib/upnpClient.js');
+const ssdp = require('../lib/ssdp.js');
+
+describe('ssdp.js', () => {
+    let deviceList, serverSettings;
+    let mockClientInstance;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        deviceList = [];
+        serverSettings = { selectedDevice: {} };
+        mockClientInstance = {
+            on: jest.fn(),
+            search: jest.fn()
+        };
+        SSDPClient.mockImplementation(() => mockClientInstance);
+    });
+
+    describe('scan', () => {
+        it('should create an SSDP client and start AVTransport search', () => {
+            ssdp.scan(deviceList, serverSettings);
+
+            expect(SSDPClient).toHaveBeenCalledWith({ explicitSocketBind: true });
+            expect(mockClientInstance.on).toHaveBeenCalledWith('response', expect.any(Function));
+            expect(mockClientInstance.search).toHaveBeenCalledWith(
+                'urn:schemas-upnp-org:service:AVTransport:1'
+            );
+        });
+
+        it('should reset the device list before scanning', () => {
+            deviceList.push({ location: 'http://existing:1234/desc.xml' });
+            expect(deviceList).toHaveLength(1);
+
+            ssdp.scan(deviceList, serverSettings);
+
+            expect(deviceList).toHaveLength(0);
+        });
+
+        it('should call getDeviceDescription when a new device responds', () => {
+            ssdp.scan(deviceList, serverSettings);
+
+            const responseCallback = mockClientInstance.on.mock.calls.find(
+                call => call[0] === 'response'
+            )[1];
+
+            const respSSDP = { LOCATION: 'http://192.168.1.50:49152/desc.xml' };
+            responseCallback(respSSDP, 200, {});
+
+            expect(upnp.getDeviceDescription).toHaveBeenCalledWith(
+                deviceList,
+                serverSettings,
+                respSSDP
+            );
+        });
+
+        it('should not call getDeviceDescription for a duplicate device location', () => {
+            ssdp.scan(deviceList, serverSettings);
+
+            const responseCallback = mockClientInstance.on.mock.calls.find(
+                call => call[0] === 'response'
+            )[1];
+
+            // Simulate the device already being present in the list
+            const location = 'http://192.168.1.50:49152/desc.xml';
+            deviceList.push({ location });
+
+            const respSSDP = { LOCATION: location };
+            responseCallback(respSSDP, 200, {});
+
+            expect(upnp.getDeviceDescription).not.toHaveBeenCalled();
+        });
+
+        it('should call getDeviceDescription for each distinct device that responds', () => {
+            ssdp.scan(deviceList, serverSettings);
+
+            const responseCallback = mockClientInstance.on.mock.calls.find(
+                call => call[0] === 'response'
+            )[1];
+
+            const resp1 = { LOCATION: 'http://192.168.1.10:49152/desc.xml' };
+            const resp2 = { LOCATION: 'http://192.168.1.20:49152/desc.xml' };
+            responseCallback(resp1, 200, {});
+            responseCallback(resp2, 200, {});
+
+            expect(upnp.getDeviceDescription).toHaveBeenCalledTimes(2);
+            expect(upnp.getDeviceDescription).toHaveBeenCalledWith(deviceList, serverSettings, resp1);
+            expect(upnp.getDeviceDescription).toHaveBeenCalledWith(deviceList, serverSettings, resp2);
+        });
+    });
+});

--- a/server/__tests__/upnpClient.test.js
+++ b/server/__tests__/upnpClient.test.js
@@ -40,7 +40,9 @@ describe('upnpClient.js', () => {
             },
             timeouts: { state: 1000, metadata: 2000 }
         };
-        // restoreAllMocks clears spied-on function overrides (e.g. jest.spyOn) in addition to clearing calls
+        // Use restoreAllMocks so that jest.spyOn overrides created inside individual tests
+        // (e.g. in callDeviceAction tests) do not leak into subsequent tests.
+        // All spies are set up inside test bodies, not in beforeEach, so this is safe.
         jest.restoreAllMocks();
     });
 
@@ -142,7 +144,7 @@ describe('upnpClient.js', () => {
             expect(io.emit).not.toHaveBeenCalled();
         });
 
-        it('should trigger metadata update when transitioning from TRANSITIONING state', done => {
+        it('should call updateDeviceMetadata when state transitions from TRANSITIONING to PLAYING', done => {
             // Set previous state to TRANSITIONING
             deviceInfo.state = { CurrentTransportState: 'TRANSITIONING' };
             serverSettings.selectedDevice.actions = ['GetTransportInfo', 'GetInfoEx'];

--- a/server/__tests__/upnpClient.test.js
+++ b/server/__tests__/upnpClient.test.js
@@ -12,6 +12,7 @@ const xml2js = require('xml2js');
 const UPnP = require("upnp-device-client");
 
 jest.mock('../lib/lib.js');
+jest.mock('../lib/lyrics.js');
 jest.mock('xml2js');
 jest.mock('upnp-device-client');
 
@@ -39,7 +40,8 @@ describe('upnpClient.js', () => {
             },
             timeouts: { state: 1000, metadata: 2000 }
         };
-        jest.clearAllMocks();
+        // restoreAllMocks clears spied-on function overrides (e.g. jest.spyOn) in addition to clearing calls
+        jest.restoreAllMocks();
     });
 
     describe('createClient', () => {
@@ -131,6 +133,42 @@ describe('upnpClient.js', () => {
             upnpClient.updateDeviceState(io, deviceInfo, serverSettings);
             expect(io.emit).toHaveBeenCalledWith('state', null);
         });
+
+        it('should not emit state when GetTransportInfo returns an error', () => {
+            deviceInfo.client = {
+                callAction: (service, action, options, cb) => cb(new Error('UPnP error'), null)
+            };
+            upnpClient.updateDeviceState(io, deviceInfo, serverSettings);
+            expect(io.emit).not.toHaveBeenCalled();
+        });
+
+        it('should trigger metadata update when transitioning from TRANSITIONING state', done => {
+            // Set previous state to TRANSITIONING
+            deviceInfo.state = { CurrentTransportState: 'TRANSITIONING' };
+            serverSettings.selectedDevice.actions = ['GetTransportInfo', 'GetInfoEx'];
+            lib.getTimeStamp.mockReturnValue(77);
+            deviceInfo.client = {
+                callAction: jest.fn()
+                    .mockImplementationOnce((service, action, options, cb) => {
+                        // First call: updateDeviceState - GetTransportInfo returns PLAYING (from TRANSITIONING)
+                        cb(null, { CurrentTransportState: 'PLAYING' });
+                    })
+                    .mockImplementationOnce((service, action, options, cb) => {
+                        // Second call: updateDeviceMetadata triggered by TRANSITIONING→PLAYING transition
+                        cb(null, { TrackMetaData: null, RelTime: '00:01:00' });
+                    })
+            };
+
+            upnpClient.updateDeviceState(io, deviceInfo, serverSettings);
+
+            setTimeout(() => {
+                try {
+                    // callAction should be called twice: GetTransportInfo + GetInfoEx (from triggered updateDeviceMetadata)
+                    expect(deviceInfo.client.callAction).toHaveBeenCalledTimes(2);
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
     });
 
     describe('updateDeviceMetadata', () => {
@@ -216,6 +254,168 @@ describe('upnpClient.js', () => {
             upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
             expect(deviceInfo.metadata).toBeNull();
         });
+
+        it('should emit metadata for GetInfoEx when TrackMetaData is null', done => {
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['GetInfoEx'];
+            deviceInfo.client.callAction.mockImplementation((service, action, params, cb) => {
+                cb(null, { TrackMetaData: null, RelTime: '00:00:30' });
+            });
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(io.emit).toHaveBeenCalledWith('metadata', expect.objectContaining({
+                        RelTime: '00:00:30',
+                        metadataTimeStamp: 12345
+                    }));
+                    expect(deviceInfo.metadata.trackMetaData).toBeUndefined();
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
+
+        it('should handle xml2js parse error in GetInfoEx callback', done => {
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['GetInfoEx'];
+            deviceInfo.client.callAction.mockImplementation((service, action, params, cb) => {
+                cb(null, { TrackMetaData: '<invalid>', RelTime: '00:00:10' });
+            });
+            xml2js.parseString.mockImplementation((xml, opts, cb) => {
+                cb(new Error('XML parse error'), null);
+            });
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(io.emit).not.toHaveBeenCalled();
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
+
+        it('should call getLyricsForMetadata when lyrics are enabled in GetInfoEx path', done => {
+            const lyrics = require('../lib/lyrics.js');
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['GetInfoEx'];
+            serverSettings.features = { lyrics: { enabled: true } };
+            deviceInfo.client.callAction.mockImplementation((service, action, params, cb) => {
+                cb(null, { TrackMetaData: '<xml/>', RelTime: '00:01:00' });
+            });
+            xml2js.parseString.mockImplementation((xml, opts, cb) => {
+                cb(null, { 'DIDL-Lite': { item: { title: 'Test' } } });
+            });
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(lyrics.getLyricsForMetadata).toHaveBeenCalledWith(io, deviceInfo, serverSettings);
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
+
+        it('should emit metadata for GetPositionInfo when TrackMetaData is null', done => {
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['GetPositionInfo'];
+            deviceInfo.client.callAction.mockImplementation((service, action, params, cb) => {
+                cb(null, { TrackMetaData: null, RelTime: '00:00:45' });
+            });
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(io.emit).toHaveBeenCalledWith('metadata', expect.objectContaining({
+                        RelTime: '00:00:45',
+                        metadataTimeStamp: 12345
+                    }));
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
+
+        it('should handle xml2js parse error in GetPositionInfo callback', done => {
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['GetPositionInfo'];
+            deviceInfo.client.callAction.mockImplementation((service, action, params, cb) => {
+                cb(null, { TrackMetaData: '<invalid>', RelTime: '00:00:10' });
+            });
+            xml2js.parseString.mockImplementation((xml, opts, cb) => {
+                cb(new Error('XML parse error'), null);
+            });
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(io.emit).not.toHaveBeenCalled();
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
+
+        it('should call getLyricsForMetadata when lyrics are enabled in GetPositionInfo path', done => {
+            const lyrics = require('../lib/lyrics.js');
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['GetPositionInfo'];
+            serverSettings.features = { lyrics: { enabled: true } };
+            deviceInfo.client.callAction.mockImplementation((service, action, params, cb) => {
+                cb(null, { TrackMetaData: '<xml/>', RelTime: '00:02:00' });
+            });
+            xml2js.parseString.mockImplementation((xml, opts, cb) => {
+                cb(null, { 'DIDL-Lite': { item: { title: 'Track' } } });
+            });
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(lyrics.getLyricsForMetadata).toHaveBeenCalledWith(io, deviceInfo, serverSettings);
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
+
+        it('should handle GetPositionInfo callAction error without emitting', done => {
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['GetPositionInfo'];
+            deviceInfo.client.callAction.mockImplementation((service, action, params, cb) => {
+                cb(new Error('Device unreachable'), null);
+            });
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(io.emit).not.toHaveBeenCalled();
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
+
+        it('should set metadata to null when no GetInfoEx or GetPositionInfo action is available', () => {
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['Play', 'Pause'];
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            expect(deviceInfo.metadata).toBeNull();
+        });
+
+        it('should handle GetInfoEx callAction error without emitting', done => {
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['GetInfoEx'];
+            deviceInfo.client.callAction.mockImplementation((service, action, params, cb) => {
+                cb(new Error('GetInfoEx error'), null);
+            });
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(io.emit).not.toHaveBeenCalled();
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
+
+        it('should create a client via ensureClient when no client is present', () => {
+            // Use a fresh UPnP mock that returns a client with callAction
+            UPnP.mockImplementation(() => ({ callAction: jest.fn() }));
+            deviceInfo = {}; // No client set - triggers real ensureClient
+            serverSettings.selectedDevice.location = 'http://1.1.1.1';
+            serverSettings.selectedDevice.actions = ['Play']; // No GetInfoEx/GetPositionInfo - goes to else
+            upnpClient.updateDeviceMetadata(io, deviceInfo, serverSettings);
+            // ensureClient should have created a client
+            expect(deviceInfo.client).toBeDefined();
+            expect(deviceInfo.metadata).toBeNull();
+        });
     });
 
     describe('callDeviceAction', () => {
@@ -234,43 +434,231 @@ describe('upnpClient.js', () => {
             upnpClient.callDeviceAction(io, 'Pause', deviceInfo, serverSettings);
             expect(io.emit).not.toHaveBeenCalled();
         });
-    });
 
-    describe('getDeviceDescription', () => {
-        it('should call getDeviceDescription on client', () => {
-            const deviceList = [];
-            const respSSDP = { LOCATION: 'http://test' };
-            const client = upnpClient.createClient(respSSDP.LOCATION);
-            client.getDeviceDescription = jest.fn((cb) => cb(null, { friendlyName: 'Test', deviceType: 'urn:upnp-org:device:MediaRenderer:1', services: { 'urn:upnp-org:serviceId:AVTransport': true } }));
-            upnpClient.getDeviceDescription(deviceList, serverSettings, respSSDP);
-            expect(client.getDeviceDescription).toBeDefined();
+        it('should not emit when device action returns an error', () => {
+            serverSettings.selectedDevice.actions = ['Pause'];
+            deviceInfo.client = {
+                callAction: (service, action, options, cb) => cb(new Error('UPnP Action Error'), null)
+            };
+            upnpClient.callDeviceAction(io, 'Pause', deviceInfo, serverSettings);
+            expect(io.emit).not.toHaveBeenCalled();
+        });
+
+        it('should include Speed option when action is Play', done => {
+            let capturedOptions;
+            // Restrict actions to only 'Play' so updateDeviceState does not trigger a second callAction
+            serverSettings.selectedDevice.actions = ['Play'];
+            deviceInfo.client = {
+                callAction: (service, action, options, cb) => {
+                    capturedOptions = options;
+                    cb(null, {});
+                }
+            };
+            upnpClient.callDeviceAction(io, 'Play', deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(capturedOptions).toMatchObject({ InstanceID: 0, Speed: 1 });
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
+        });
+
+        it('should not include Speed option for non-Play actions', done => {
+            let capturedOptions;
+            serverSettings.selectedDevice.actions = ['Pause'];
+            deviceInfo.client = {
+                callAction: (service, action, options, cb) => {
+                    capturedOptions = options;
+                    cb(null, {});
+                }
+            };
+            upnpClient.callDeviceAction(io, 'Pause', deviceInfo, serverSettings);
+            setTimeout(() => {
+                try {
+                    expect(capturedOptions).not.toHaveProperty('Speed');
+                    expect(capturedOptions).toMatchObject({ InstanceID: 0 });
+                    done();
+                } catch (e) { done(e); }
+            }, 100);
         });
     });
 
-    // describe('getServiceDescription', () => {
-    //     it('should add device to deviceList and set default selected device', done => {
-    //         const deviceList = [];
-    //         const deviceClient = {
-    //             getServiceDescription: jest.fn()
-    //         };
-    //         const respSSDP = { LOCATION: 'http://test' };
-    //         const deviceDesc = {
-    //             friendlyName: 'Test',
-    //             manufacturer: 'Linkplay',
-    //             modelName: 'WiiM',
-    //             services: { 'urn:upnp-org:serviceId:AVTransport': true }
-    //         };
-    //         deviceClient.getServiceDescription
-    //             .mockImplementationOnce((service, cb) => cb(null, { actions: { Play: {}, Pause: {} } }))
-    //             .mockImplementationOnce((service, cb) => cb(null, { actions: { SetVolume: {} } }));
+    describe('getDeviceDescription', () => {
+        it('should create a client and call getDeviceDescription', () => {
+            const mockInstance = {
+                getDeviceDescription: jest.fn((cb) => cb(null, {
+                    friendlyName: 'Test Device',
+                    deviceType: 'urn:upnp-org:device:MediaRenderer:1',
+                    services: {} // No AVTransport - takes the OpenHome path
+                })),
+                getServiceDescription: jest.fn()
+            };
+            UPnP.mockImplementation(() => mockInstance);
 
-    //         upnpClient.getServiceDescription(deviceList, serverSettings, deviceClient, respSSDP, deviceDesc);
+            const deviceList = [];
+            const respSSDP = { LOCATION: 'http://test' };
+            upnpClient.getDeviceDescription(deviceList, serverSettings, respSSDP);
 
-    //         setTimeout(() => {
-    //             expect(deviceList.length).toBe(1);
-    //             expect(serverSettings.selectedDevice.friendlyName).toBe('Test');
-    //             done();
-    //         }, 10);
-    //     });
-    // });
+            expect(mockInstance.getDeviceDescription).toHaveBeenCalled();
+        });
+
+        it('should handle error from getDeviceDescription callback', () => {
+            const mockInstance = {
+                getDeviceDescription: jest.fn((cb) => cb(new Error('Connection refused'), null)),
+                getServiceDescription: jest.fn()
+            };
+            UPnP.mockImplementation(() => mockInstance);
+
+            const deviceList = [];
+            const respSSDP = { LOCATION: 'http://192.168.1.100:49152/desc.xml' };
+            upnpClient.getDeviceDescription(deviceList, serverSettings, respSSDP);
+
+            expect(mockInstance.getDeviceDescription).toHaveBeenCalled();
+            expect(deviceList).toHaveLength(0);
+        });
+
+        it('should proceed to getServiceDescription when AVTransport is supported', () => {
+            const mockInstance = {
+                getDeviceDescription: jest.fn((cb) => cb(null, {
+                    friendlyName: 'WiiM Pro',
+                    deviceType: 'urn:schemas-upnp-org:device:MediaRenderer:1',
+                    manufacturer: 'Linkplay',
+                    modelName: 'WiiM Pro',
+                    services: { 'urn:upnp-org:serviceId:AVTransport': {} }
+                })),
+                getServiceDescription: jest.fn((service, cb) => cb(null, { actions: { Play: {}, Pause: {} } }))
+            };
+            UPnP.mockImplementation(() => mockInstance);
+
+            const deviceList = [];
+            const respSSDP = { LOCATION: 'http://192.168.1.100:49152/desc.xml' };
+            const localSettings = { selectedDevice: {} };
+            upnpClient.getDeviceDescription(deviceList, localSettings, respSSDP);
+
+            expect(mockInstance.getServiceDescription).toHaveBeenCalledWith('AVTransport', expect.any(Function));
+        });
+
+        it('should not call getServiceDescription for OpenHome devices (no AVTransport)', () => {
+            const mockInstance = {
+                getDeviceDescription: jest.fn((cb) => cb(null, {
+                    friendlyName: 'OpenHome Device',
+                    deviceType: 'urn:schemas-upnp-org:device:MediaRenderer:1',
+                    manufacturer: 'SomeManufacturer',
+                    modelName: 'SomeModel',
+                    services: {} // No AVTransport service
+                })),
+                getServiceDescription: jest.fn()
+            };
+            UPnP.mockImplementation(() => mockInstance);
+
+            const deviceList = [];
+            const respSSDP = { LOCATION: 'http://192.168.1.200:49152/desc.xml' };
+            upnpClient.getDeviceDescription(deviceList, serverSettings, respSSDP);
+
+            expect(mockInstance.getServiceDescription).not.toHaveBeenCalled();
+            expect(deviceList).toHaveLength(0);
+        });
+    });
+
+    describe('getServiceDescription', () => {
+        it('should add device with actions and auto-select WiiM device', done => {
+            const deviceList = [];
+            const respSSDP = { LOCATION: 'http://192.168.1.100:49152/desc.xml' };
+            const deviceDesc = {
+                friendlyName: 'WiiM Pro',
+                manufacturer: 'Linkplay',
+                modelName: 'WiiM Pro',
+                services: {}
+            };
+            const deviceClient = {
+                getServiceDescription: jest.fn((service, cb) => cb(null, { actions: { Play: {}, Pause: {}, Stop: {} } }))
+            };
+            const localSettings = { selectedDevice: {} };
+
+            upnpClient.getServiceDescription(deviceList, localSettings, deviceClient, respSSDP, deviceDesc);
+
+            setTimeout(() => {
+                expect(deviceList).toHaveLength(1);
+                expect(deviceList[0].actions).toEqual({ Play: {}, Pause: {}, Stop: {} });
+                // WiiM/Linkplay device should be auto-selected when none is selected yet
+                expect(localSettings.selectedDevice.friendlyName).toBe('WiiM Pro');
+                expect(localSettings.selectedDevice.actions).toEqual(['Play', 'Pause', 'Stop']);
+                expect(lib.saveSettings).toHaveBeenCalledWith(localSettings);
+                done();
+            }, 10);
+        });
+
+        it('should add device without actions when getServiceDescription returns an error', done => {
+            const deviceList = [];
+            const respSSDP = { LOCATION: 'http://192.168.1.100:49152/desc.xml' };
+            const deviceDesc = {
+                friendlyName: 'WiiM Mini',
+                manufacturer: 'Linkplay',
+                modelName: 'WiiM Mini',
+                services: {}
+            };
+            const deviceClient = {
+                getServiceDescription: jest.fn((service, cb) => cb(new Error('Service unavailable'), null))
+            };
+            const localSettings = { selectedDevice: {} };
+
+            upnpClient.getServiceDescription(deviceList, localSettings, deviceClient, respSSDP, deviceDesc);
+
+            setTimeout(() => {
+                expect(deviceList).toHaveLength(1);
+                expect(deviceList[0].actions).toEqual({});
+                done();
+            }, 10);
+        });
+
+        it('should not auto-select non-WiiM/non-Linkplay device when no device is selected', done => {
+            const deviceList = [];
+            const respSSDP = { LOCATION: 'http://192.168.1.200:49152/desc.xml' };
+            const deviceDesc = {
+                friendlyName: 'Generic Renderer',
+                manufacturer: 'SomeManufacturer',
+                modelName: 'SomeModel',
+                services: {}
+            };
+            const deviceClient = {
+                getServiceDescription: jest.fn((service, cb) => cb(null, { actions: { Play: {} } }))
+            };
+            const localSettings = { selectedDevice: {} };
+
+            upnpClient.getServiceDescription(deviceList, localSettings, deviceClient, respSSDP, deviceDesc);
+
+            setTimeout(() => {
+                expect(deviceList).toHaveLength(1);
+                // Should NOT auto-select a non-WiiM/Linkplay device
+                expect(localSettings.selectedDevice.friendlyName).toBeUndefined();
+                done();
+            }, 10);
+        });
+
+        it('should update selected device when location matches existing selection', done => {
+            const deviceList = [];
+            const location = 'http://192.168.1.100:49152/desc.xml';
+            const respSSDP = { LOCATION: location };
+            const deviceDesc = {
+                friendlyName: 'WiiM Pro',
+                manufacturer: 'SomeManufacturer', // Not Linkplay
+                modelName: 'SomeModel',           // Not WiiM
+                services: {}
+            };
+            const deviceClient = {
+                getServiceDescription: jest.fn((service, cb) => cb(null, { actions: { Play: {}, Next: {} } }))
+            };
+            // Location already stored as selected device
+            const localSettings = { selectedDevice: { location } };
+
+            upnpClient.getServiceDescription(deviceList, localSettings, deviceClient, respSSDP, deviceDesc);
+
+            setTimeout(() => {
+                // Should update because location matches
+                expect(localSettings.selectedDevice.friendlyName).toBe('WiiM Pro');
+                expect(lib.saveSettings).toHaveBeenCalled();
+                done();
+            }, 10);
+        });
+    });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -211,7 +211,7 @@ app.get("/proxy-art", limiter, function (req, res) {
                 // console.log("Determined content type:", contentType);
             }
 
-            // If the response is valid, pipe it to the client
+            // If the response is invalid, not an image, tell the client and stop processing the response
             if (!contentType || !contentType.startsWith('image/')) {
                 res.status(415).send("<div>Unsupported Media Type</div>");
                 resp.destroy(); // Stop receiving data
@@ -224,7 +224,7 @@ app.get("/proxy-art", limiter, function (req, res) {
             // Pipe the response to the client
             res.writeHead(resp.statusCode, headers);
             res.write(chunk); // Write the first chunk that we already received
-            resp.pipe(res); // Pipe the rest of the response
+            resp.pipe(res); // Pipe the rest of the response chunks directly to the client
 
         });
 

--- a/server/index.js
+++ b/server/index.js
@@ -168,20 +168,84 @@ app.get("/proxy-art", limiter, function (req, res) {
     const options = {
         rejectUnauthorized: false, // Ignore self-signed certificate
     };
+    let identified = false;
 
-    https.get(targetUrl.href, options, (resp) => {
-        // If the response is valid, pipe it to the client
-        // Valid content-types could be: image/jpeg, image/png, image/webp, image/svg+xml, image/gif, etc.
-        if (!resp.headers['content-type'] || !resp.headers['content-type'].startsWith('image/')) {
-            res.status(415).send("<div>Unsupported Media Type</div>");
-            return;
-        }
-        res.writeHead(resp.statusCode, resp.headers);
-        resp.pipe(res);
-    })
-        .on('error', function (e) {
-            res.status(404).send("<div>404 Not Found</div>");
+    // Make the request to the target URL
+    const request = https.get(targetUrl.href, options, (resp) => {
+
+        // What content type do we have?
+        let contentType = resp.headers['content-type'];
+
+        // Wait for the first chunk to inspect the content if no content type is provided or if the content type does not start with image/,
+        // to check if it's a valid image and determine the content type based on the magic bytes,
+        // as some devices do not provide a content-type header or provide an incorrect one.
+        resp.once('data', (chunk) => {
+            identified = true;
+
+            if (!contentType || !contentType.startsWith('image/')) {
+                // console.log("Content type:", resp.headers['content-type']);
+                const magicBytes = chunk.toString('hex', 0, 4).toUpperCase();
+                // console.log("Magic bytes:", magicBytes);
+
+                switch (true) {
+                    case magicBytes.startsWith('FFD8FF'):
+                        contentType = 'image/jpeg';
+                        break;
+                    case magicBytes.startsWith('89504E47'):
+                        contentType = 'image/png';
+                        break;
+                    case magicBytes.startsWith('47494638'):
+                        contentType = 'image/gif';
+                        break;
+                    case magicBytes.startsWith('52494646'): // RIFF (WebP)
+                        contentType = 'image/webp';
+                        break;
+                    case magicBytes.startsWith('3C737667'): // <svg
+                    case magicBytes.startsWith('3C3F786D'): // <?xm
+                        contentType = 'image/svg+xml';
+                        break;
+                    case magicBytes.startsWith('424D'): // BMP (Bitmap)
+                        contentType = 'image/bmp';
+                        break;
+                }
+                // console.log("Determined content type:", contentType);
+            }
+
+            // If the response is valid, pipe it to the client
+            if (!contentType || !contentType.startsWith('image/')) {
+                res.status(415).send("<div>Unsupported Media Type</div>");
+                resp.destroy(); // Stop receiving data
+                return;
+            }
+
+            // Update the content-type header for the response to the client
+            const headers = { ...resp.headers, 'content-type': contentType };
+
+            // Pipe the response to the client
+            res.writeHead(resp.statusCode, headers);
+            res.write(chunk); // Write the first chunk that we already received
+            resp.pipe(res); // Pipe the rest of the response
+
         });
+
+        // If the response ends without us being able to identify the content type, we return an error
+        resp.once('end', () => {
+            if (!identified && !res.writableEnded) {
+                res.status(415).send("<div>Empty or Unsupported Response</div>");
+            }
+        });
+
+        // Handle errors in the response stream
+        resp.on('error', (e) => {
+            if (!res.writableEnded) res.status(502).send("<div>Gateway Error</div>");
+        });
+
+    })
+
+    // Handle errors in the request to the target URL
+    request.on('error', function (e) {
+        if (!res.writableEnded) res.status(404).send("<div>404 Not Found</div>");
+    });
 
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -175,6 +175,7 @@ app.get("/proxy-art", limiter, function (req, res) {
 
         // What content type do we have?
         let contentType = resp.headers['content-type'];
+        // console.log("Content type:", contentType);
 
         // Wait for the first chunk to inspect the content if no content type is provided or if the content type does not start with image/,
         // to check if it's a valid image and determine the content type based on the magic bytes,
@@ -183,7 +184,6 @@ app.get("/proxy-art", limiter, function (req, res) {
             identified = true;
 
             if (!contentType || !contentType.startsWith('image/')) {
-                // console.log("Content type:", resp.headers['content-type']);
                 const magicBytes = chunk.toString('hex', 0, 4).toUpperCase();
                 // console.log("Magic bytes:", magicBytes);
 
@@ -244,6 +244,7 @@ app.get("/proxy-art", limiter, function (req, res) {
 
     // Handle errors in the request to the target URL
     request.on('error', function (e) {
+        // console.error("Error fetching album art:", e);
         if (!res.writableEnded) res.status(404).send("<div>404 Not Found</div>");
     });
 


### PR DESCRIPTION
## 🧾 Summary

Updated artwork cache handling. AirPlay no longer send the Content-Type with the artwork, hence no image was shown.
Fixed it in a way that in case no Content-Type was provided, it sniffs the package to tell if it is an image and what kind.

Kudos to @Stargazer2026 and @UnicronBE for pointing out the bug and providing solutions.

Added some unit tests

## 🔧 Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [x] Chore (deps, refactor)
- [ ] Documentation

## ✔️ What was done?

- Changes to the artwork proxy handling
- Added unit tests
- Version bump

## 🧪 Test information

Manually tested several audio/network sources. Works with Plex, AirPlay, DLNA and other streaming services.

## 📸 Screenshots (optional)

N/A

## ⛓️ Related issues

Closes #47 
